### PR TITLE
Various with/without fixes, including fixing #11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -76,23 +76,23 @@ COPY [{SPEC_BASENAME}] /home/dev/rpmbuild/SPECS/
 
 CMD if [ "${DOCKRPM_DEBUG}" == "0" ]; then \
       sudo yum clean --disablerepo=* --enablerepo=rpmdocker metadata && \
+      eval RPMBUILD_ARGS=(${RPMBUILD_ARGS}) && \
       srpm_name=$(rpmbuild -bs /home/dev/rpmbuild/SPECS/[{SPEC_BASENAME}] \
-          -D "_srcrpmdir /tmp" [{RPMBUILD_ARGS}] | \grep "^Wrote: " | \
+          -D "_srcrpmdir /tmp" "${RPMBUILD_ARGS[@]}" | \grep "^Wrote: " | \
           sed 's/Wrote: \(.*\)/\1/') && \
       srpm_name2=$(echo $srpm_name | sed 's|nosrc|src|') && \
       if [ "$srpm_name" != "$srpm_name2" ]; then \
         mv $srpm_name $srpm_name2; \
       fi && \
-      #srpm_name=$(rpmbuild -bs /home/dev/rpmbuild/SPECS/[{SPEC_BASENAME}] [{RPMBUILD_ARGS}] | \grep "^Wrote: " | sed 's/Wrote: \(.*\)/\1/') && \
       #Thank you https://bugzilla.redhat.com/show_bug.cgi?id=1166126 :(
       sudo yum-builddep -y ${srpm_name2} ; \
     fi && \
     if [ "${DOCKRPM_BASH}" == "1" ]; then \
       echo "When you are ready, run:" && \
-      echo "rpmbuild -ba /home/dev/rpmbuild/SPECS/[{SPEC_BASENAME}]" && \
+      echo "rpmbuild -ba ${RPMBUILD_ARGS[@]} /home/dev/rpmbuild/SPECS/[{SPEC_BASENAME}]" && \
       bash; \
     else \
-      rpmbuild -ba /home/dev/rpmbuild/SPECS/[{SPEC_BASENAME}] && \
+      rpmbuild -ba "${RPMBUILD_ARGS[@]}" /home/dev/rpmbuild/SPECS/[{SPEC_BASENAME}] && \
       createrepo ~/rpmbuild/RPMS -o /tmp && \
       rm -rvf ~/rpmbuild/RPMS/repodata && \
       mv /tmp/repodata ~/rpmbuild/RPMS/ && \

--- a/Dockerfile_dep_check
+++ b/Dockerfile_dep_check
@@ -32,7 +32,7 @@ CMD sed 's|%%|%%%%|g' > $HOME/rpmbuild/SPECS/rpm_preparse.spec && \
     #reescapes them and hopefully NOTHING GOES WRONG! :-\
     set -o pipefail && \
     #catch failing grep/seds... they shouldn't be, this helps with debug only, of course
-    eval "RPMBUILD_ARGS=(${RPMBUILD_ARGS})" && \
+    eval RPMBUILD_ARGS=(${RPMBUILD_ARGS}) && \
     rpmspec "${RPMBUILD_ARGS[@]}" -D "debug_package %{nil}" -P $HOME/rpmbuild/SPECS/rpm_preparse.spec > $HOME/rpmbuild/SPECS/rpm.spec && \
     #parse the spec file, debug_package must be disabled or else two debug packages will be made, and fail
     spectool -g -n -A -C $HOME/rpmbuild/SOURCES $HOME/rpmbuild/SPECS/rpm.spec | \

--- a/Dockerfile_other
+++ b/Dockerfile_other
@@ -21,7 +21,7 @@ CMD if [ "${CREATEREPO}" == "1" ]; then\
       mv /tmp/repodata ~/rpmbuild/SRPMS/; \
     fi && \
     if [ "${SPECTOOL}" == "1" ]; then \
-      eval "WITH_ARGS=($WITH_ARGS)" && \
+      eval WITH_ARGS=($WITH_ARGS) && \
       rpmspec -P /dev/stdin "${WITH_ARGS[@]}" | \
       spectool -g -n -A -; \
     fi

--- a/dockrpm
+++ b/dockrpm
@@ -240,9 +240,15 @@ class DockRpm(object):
 
     
   def search_local(self, package_info, package_name_suffix='_local'):
-    cmd = ['python', '/search_local.py'] + package_info
+    cmd = ['python', '/search_local.py']
+    if len(package_info) == 1:
+      cmd.append(package_info[0])
+    else:
+      cmd.extend([package_info[0], '-t', package_info[1], '-v', package_info[2]])
+    cmd.extend(withs_to_defines(getattr(self.args, 'with'), self.args.without))
+
     docker_args = ['-v', '%s:/specs' % self.specs_dir_docker,
-                   '-v', '%s:/search_local.py' % posixpath.join(self.code_dir_docker, 'search_local.py')]
+                   '-v', '%s:/search_local.py:ro' % posixpath.join(self.code_dir_docker, 'search_local.py')]
     pid = self.run_other_piped(cmd, docker_args)
     return pid.communicate()[0].strip()
 
@@ -368,7 +374,6 @@ class DockRpm(object):
       copy_tree(self.args.mount_repo, self.repo_dir)
     if self.args.mount_gpg:
       copy_tree(self.args.mount_gpg, self.gpg_dir)
-    print self.args
 
     if os.path.exists(self.common_inc):
       shutil.copy(self.common_inc, self.source_dir)
@@ -428,7 +433,8 @@ class DockRpm(object):
           cmd = cmd[:-1] + \
                 ['-t', '-v', '%s:/home/dev/rpmbuild/SPECS/rpm_orig.spec' % \
                              (self.spec_path_docker),
-                 '-e', 'DOCKRPM_BASH=1'] + cmd[-1:]
+                 '-e', 'DOCKRPM_BASH=1'] + cmd[-1:] + ['bash']
+          fid = None
 
         self.logger.debug(cmd_to_str(cmd))
         Popen(cmd, stdin=fid).wait(0)
@@ -581,7 +587,6 @@ class DockRpm(object):
     docker_env['SPEC_BASENAME'] = self.spec_basename
     docker_env['USER_UID'] = str(self.args.uid)
     docker_env['USER_GID'] = str(self.args.gid)
-    docker_env['RPMBUILD_ARGS'] = ' '.join(self.rpmbuild_args)
 
     #docker+ the Dockerfile
     self.dockerp(os.path.join(self.code_dir, 'Dockerfile'), self.dockerfile,
@@ -650,6 +655,7 @@ class DockRpm(object):
     cmd = ['docker', 'run', '-i', 
            '-v', '%s:/home/dev/rpmbuild/RPMS' % self.rpm_dir_docker,
            '-v', '%s:/home/dev/rpmbuild/SRPMS' % self.srpm_dir_docker,
+           '-e', 'RPMBUILD_ARGS=%s' % cmd_to_str(self.rpmbuild_args),
            '--name', container_name] + docker_options + self.extra_args + \
            [image_name]
     self.logger.debug(cmd_to_str(cmd))

--- a/search_local.py
+++ b/search_local.py
@@ -5,6 +5,7 @@ import os
 from subprocess import Popen, PIPE
 import shutil
 from distutils.dir_util import mkpath
+import argparse
 
 def test_version(version1, version2, test):
   try:
@@ -28,15 +29,15 @@ def test_version(version1, version2, test):
     raise Exception('Unexpected logic test %s' % test)
 
 
-def get_rpm_names_from_specfile(spec_path, source_dir):
-  cmd = ['rpm', '-q', '-D', '_sourcedir %s' % source_dir, 
-         '--qf', '%{NAME}\t%{VERSION}\n', '--specfile', spec_path]
+def get_rpm_names_from_specfile(spec_path, source_dir, other=[]):
+  cmd = ['rpmspec', '-q', '-D', '_sourcedir %s' % source_dir] + other + \
+        ['--qf', '%{NAME}\t%{VERSION}\n%{PROVIDES}\t%{VERSION}\n', spec_path]
   pid = Popen(cmd, stdout=PIPE, stderr=PIPE)
   stdout = pid.communicate()[0][:-1] #get rid of trailing newline
   pid.wait()
   return map(lambda x:x.split('\t'), stdout.splitlines())
 
-def search_local(package_name, version_test=None, version=None, specs_dir='/specs', package_name_suffix='_local'):
+def search_local(package_name, version_test=None, version=None, specs_dir='/specs', package_name_suffix='_local', other=[]):
   #I think the package_name_suffix feature should be removed now...
   local_pacakge_name = package_name.split('-')
   local_pacakge_names = ['-'.join(local_pacakge_name[0:x] + 
@@ -63,7 +64,7 @@ def search_local(package_name, version_test=None, version=None, specs_dir='/spec
       mkpath(os.path.dirname(common_inc))
       shutil.copy(os.path.join(specs_dir, 'common.inc'), common_inc)
       temp_common_inc = True
-    rpm_names = get_rpm_names_from_specfile(spec, os.path.join(os.path.dirname(spec), 'source'))
+    rpm_names = get_rpm_names_from_specfile(spec, os.path.join(os.path.dirname(spec), 'source'), other=other)
     if temp_common_inc:
       os.remove(common_inc)
     for rpm_name in rpm_names:
@@ -76,4 +77,10 @@ def search_local(package_name, version_test=None, version=None, specs_dir='/spec
             return os.path.relpath(spec, specs_dir)
 
 if __name__=='__main__':
-  print search_local(*sys.argv[1:])
+  parser = argparse.ArgumentParser()
+  parser.add_argument('name')
+  parser.add_argument('-t', default=None)
+  parser.add_argument('-v', default=None)
+  (args, other) = parser.parse_known_args()
+
+  print search_local(args.name, args.t, args.v, other=other)


### PR DESCRIPTION
-dockrpm - Fixed with/without args for yum-builddep call
-dockrpm - Fixed with/without args for rmpbuild call and helpful debug messages
-dep_check - Fixed with/without args to actually work
-other - Fixed with/without args to actually work
-dep_check - Added with/without args to search_local. This fixes #11
-dep_check - Added provides support to search_local. This fixes #11
-dockrpm - Added --bash debug support for dep_check image... not fully functional,
but good enough to support dropping into the container for easier debugging.
