### PR TITLE
Fix #14

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ SHELL := /usr/bin/env bash
 
 FIX_DEP_ARG = --assumeno
 
-ARGS = --debug-on-fail false
+ARGS = --debug-on-fail=false
 
 ENABLE_REPO = 1
 

--- a/argparse_dissect.py
+++ b/argparse_dissect.py
@@ -90,25 +90,23 @@ def filter_args(namespace, args=None, exclude=[]):
                                     namespace._ordered_args_option_strings,
                                     namespace._ordered_args_values):
     
+    args_length = 0
+
     if not isinstance(values, (list, tuple, set)):
       values = [values]
     #canonicalize
 
-    if arg_name in exclude:
-      index += len(flag)
-      index += len(values)
-      continue
+    if flag and '=' in args[index]:
+      args_length -= 1
+    #Fix index error when argument is --foo=bar instead of --foo bar. This 
+    #should not be tricked by --foo=bar=zoo or --foo bar=zoo. Also if it is an
+    #positional argument(if flag), don't check.
 
-    #filtered_args2.extend(flag)
-    #if isinstance(values, list):
-    #  filtered_args2.extend(values)
-    #else:
-    #  filtered_args2.append(values)
+    args_length += len(flag)
+    args_length += len(values)
 
-    filtered_args.extend(args[index:index+len(flag)])
-    index += len(flag)
-
-    filtered_args.extend(args[index:index+len(values)])
-    index += len(values)
+    if arg_name not in exclude:
+      filtered_args.extend(args[index:index+args_length])
+    index += args_length
 
   return filtered_args

--- a/dockrpm
+++ b/dockrpm
@@ -375,9 +375,12 @@ class DockRpm(object):
     if self.args.mount_gpg:
       copy_tree(self.args.mount_gpg, self.gpg_dir)
 
-    if os.path.exists(self.common_inc):
+    if os.path.exists(self.common_inc) and \
+       not os.path.exists(os.path.join(self.source_dir, 
+                                       os.path.basename(self.common_inc))):
       shutil.copy(self.common_inc, self.source_dir)
-      #should this always overwrite? or never? or something inbetween?
+      #should this always overwrite? or never? or something inbetween? I choose
+      #never by default. 
     
     self.dockerp(os.path.join(self.code_dir, 'Dockerfile_dep_check'),
                  self.dockerfile_dep_check,
@@ -455,7 +458,8 @@ class DockRpm(object):
           #arg list instead
           match_spec_path = os.path.join(self.specs_dir, match)
           dep_args = [match_spec_path] + argparse.filter_args(self.args, None, 
-                                                    ['spec', 'with', 'without'])
+                                                    ['spec'])
+          self.logger.debug('Calling DockRpm with args: %s' % str(dep_args))
           DockRpm(dep_args).main(setup_logging=False)
         else:
           raise Exception('No match for package %s' % missing_package)
@@ -504,7 +508,7 @@ class DockRpm(object):
 
   def run_create_repo(self):
     self.build_other_image()
-    cmd = ['docker', 'run', '-e', 'CREATEREPO=1',
+    cmd = ['docker', 'run', '--rm', '-e', 'CREATEREPO=1',
            '-v', '%s:/home/dev/rpmbuild/RPMS' % self.rpm_dir_docker,
            '-v', '%s:/home/dev/rpmbuild/SRPMS' % self.srpm_dir_docker,
            self.dockerfile_other_imagename]
@@ -517,7 +521,7 @@ class DockRpm(object):
 
     with_args = cmd_to_str(withs_to_defines(withs, withouts))
     
-    cmd = ['docker', 'run', '-i', '-e', 'SPECTOOL=1', 
+    cmd = ['docker', 'run', '-i', '--rm', '-e', 'SPECTOOL=1', 
            '-e', 'WITH_ARGS=%s' % with_args,
            '-v', '%s:/home/dev/rpmbuild/SOURCES:ro' % self.source_dir_docker,
            self.dockerfile_other_imagename]
@@ -526,7 +530,7 @@ class DockRpm(object):
 
   def run_other(self, cmd, docker_args=[]):
     self.build_other_image()
-    cmd = ['docker', 'run'] + docker_args + \
+    cmd = ['docker', 'run', '--rm'] + docker_args + \
           [self.dockerfile_other_imagename] + cmd
     self.logger.debug(cmd_to_str(cmd))
     with PopenRedirect(LoggerFile(self.logger.debug)) as fid:


### PR DESCRIPTION
-makefile - Put the default ARGS back to the = usage
-argparse - Change the indexing routine to actually be easier to read and check
for the existent of a = in the first argument in an argument set. This allows
for easily compensating the argument index and fixes the problem for #14
-dockrpm - Copy common.inc only if it does not exist now.
-other - Added --rm flag that was missing for the other docker containers
